### PR TITLE
fix Quaternion.slerp for small angles

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -535,12 +535,13 @@ Object.assign( Quaternion.prototype, {
 
 		var sinHalfTheta = Math.sqrt( 1.0 - cosHalfTheta * cosHalfTheta );
 
-		if ( Math.abs( sinHalfTheta ) < 0.001 ) {
+		if ( sinHalfTheta * sinHalfTheta <= Number.EPSILON ) {
 
-			this._w = 0.5 * ( w + this._w );
-			this._x = 0.5 * ( x + this._x );
-			this._y = 0.5 * ( y + this._y );
-			this._z = 0.5 * ( z + this._z );
+			var s = 1 - t;
+			this._w = s * w + t * this._w;
+			this._x = s * x + t * this._x;
+			this._y = s * y + t * this._y;
+			this._z = s * z + t * this._z;
 
 			return this;
 

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -533,9 +533,9 @@ Object.assign( Quaternion.prototype, {
 
 		}
 
-		var sinHalfTheta = Math.sqrt( 1.0 - cosHalfTheta * cosHalfTheta );
+		var sqrSinHalfTheta = 1.0 - cosHalfTheta * cosHalfTheta;
 
-		if ( sinHalfTheta * sinHalfTheta <= Number.EPSILON ) {
+		if ( sqrSinHalfTheta <= Number.EPSILON ) {
 
 			var s = 1 - t;
 			this._w = s * w + t * this._w;
@@ -547,6 +547,7 @@ Object.assign( Quaternion.prototype, {
 
 		}
 
+		var sinHalfTheta = Math.sqrt( sqrSinHalfTheta );
 		var halfTheta = Math.atan2( sinHalfTheta, cosHalfTheta );
 		var ratioA = Math.sin( ( 1 - t ) * halfTheta ) / sinHalfTheta,
 			ratioB = Math.sin( t * halfTheta ) / sinHalfTheta;


### PR DESCRIPTION
Previous implementation relied on average quaternions (t=0.5) for small angles.
Now it uses the same approach as Quaternion.slerpFlat (same threshold and lerp interpolation)